### PR TITLE
Client auth cache fix

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,8 @@ import { Inter } from "next/font/google";
 
 import SessionProvider from "@/comps/SessionProvider";
 import { getServerAuthSession } from "@/server/auth";
+import { Suspense } from "react";
+import { Spinner } from "flowbite-react";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -26,12 +28,14 @@ export default async function RootLayout({
   return (
     <html lang="en">
       <body className={`font-sans ${inter.variable}`}>
-        <SessionProvider session={session}>
-          <Nav />
-          <main className="flex min-h-screen w-full flex-col justify-start bg-gradient-to-b from-[#2e026d] to-[#15162c] text-white md:items-start">
-            <span className="m-8 py-3">{children}</span>
-          </main>
-        </SessionProvider>
+        <Suspense fallback={<Spinner />}>
+          <SessionProvider session={session}>
+            <Nav />
+            <main className="flex min-h-screen w-full flex-col justify-start bg-gradient-to-b from-[#2e026d] to-[#15162c] text-white md:items-start">
+              <span className="m-8 py-3">{children}</span>
+            </main>
+          </SessionProvider>
+        </Suspense>
       </body>
     </html>
   );

--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,5 @@
+import { Spinner } from "flowbite-react";
+
+export default function Loading() {
+  return <Spinner />;
+}

--- a/src/app/users/page.tsx
+++ b/src/app/users/page.tsx
@@ -1,18 +1,23 @@
 import ProfilePic from "@/comps/ProfilePic";
 import User from "@/db/Models/User";
 import connect from "@/db/connect";
-import { cache } from "react";
+//import { unstable_cache } from "next/cache";
 
-export const revalidate = 60;
-export const dynamic = "force-dynamic";
+export const revalidate = 3600; // 1 hour
+export const dynamic = "force-static";
+
+// const cachedUsers = unstable_cache(
+//   async () => {
+//     await connect();
+//     return await User.find({});
+//   },
+//   ["users"],
+//   { revalidate: 30 * 60 },
+// );
 
 export default async function Users() {
-  const cachedUsers = cache(async () => {
-    await connect();
-    return await User.find({});
-  });
-
-  const users = await cachedUsers();
+  await connect();
+  const users = await User.find({});
   return (
     <div>
       <h1 className="mb-2 text-5xl font-extrabold">Users</h1>
@@ -23,7 +28,7 @@ export default async function Users() {
               <div className="space-y-1 font-medium dark:text-white">
                 <div>{user.name}</div>
                 <div className="text-sm text-gray-500 dark:text-gray-400">
-                  Last login {user.lastLogin.toLocaleDateString()}
+                  Last login {new Date(user.lastLogin).toLocaleDateString()}
                 </div>
               </div>
             </ProfilePic>

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -37,15 +37,13 @@ declare module "next-auth" {
  */
 export const authOptions: NextAuthOptions = {
   callbacks: {
-    session: async ({ session, token }) => {
-      return {
-        ...session,
-        user: {
-          ...session.user,
-          id: token.sub,
-        },
-      };
-    },
+    session: async ({ session, token }) => ({
+      ...session,
+      user: {
+        ...session.user,
+        id: token.sub,
+      },
+    }),
     signIn: async ({ user }) => {
       try {
         await connect();


### PR DESCRIPTION
Apparently if you force-static a page (more specifically a part of a page), the useSession client hook will not be able to fetch the current session as next.js entirely disables cookies (i think) when forced static. This behavior is still present even if the given client component is outside the static page (navbar in our instance resides outside of the static users page). Intuitively, I would think that next.js's caching behavior is on a per page-component basis, but it's the entire route. Pretty ridiculous.

To solve this issue, we'll just make an external request to the server to figure out the client's session. This is a temporary fix and will most certainly come back to haunt us in the future, but for now, we'll continue as-is.